### PR TITLE
Include peak shape into the optimization step

### DIFF
--- a/src/background.jl
+++ b/src/background.jl
@@ -1,4 +1,5 @@
 using CovarianceFunctions
+using LinearAlgebra
 const DEFAULT_RANK_TOL = 1e-6
 
 struct BackgroundModel{T, KT, AT<:AbstractMatrix{T}, UT<:AbstractMatrix, ST<:AbstractVector, LT, CT}
@@ -10,7 +11,7 @@ struct BackgroundModel{T, KT, AT<:AbstractMatrix{T}, UT<:AbstractMatrix, ST<:Abs
     c::CT # temporary storage for model parameters
 end
 
-get_param_nums(B::BackgroundModel) = length(S)
+get_param_nums(B::BackgroundModel) = length(B.S)
 get_free_params(B::BackgroundModel) = B.c
 
 function BackgroundModel(x::AbstractVector, k, l::Real, λ::Real = 1; rank_tol::Real = DEFAULT_RANK_TOL)
@@ -56,7 +57,7 @@ end
 # least-squares prior for background model to be used in conjunction with LevenbergMarquart
 # computes
 function lm_prior!(p::AbstractVector, B::BackgroundModel, c::AbstractVector)
-    if isnothing(U)
+    if isnothing(B.U)
         @. p = B.λ * c
     else
         @. p = B.λ * c / B.S

--- a/src/crystalphase.jl
+++ b/src/crystalphase.jl
@@ -25,10 +25,10 @@ end
 
 Base.Bool(CP::CrystalPhase) = true
 Base.Bool(CPs::AbstractVector{<:CrystalPhase}) = true
-get_param_nums(CP::CrystalPhase) = CP.cl.free_param + 2
+get_param_nums(CP::CrystalPhase) = CP.cl.free_param + 2 + get_param_nums(CP.profile)
 
 function CrystalPhase(_stn::String, wid_init::Real=.1,
-                      profile=Lorentz())
+                      profile::PeakProfile=PseudoVoigt(0.5))
     f = split(_stn, '\n')
     lattice_info = split(f[1], ',')
     id = parse(Int64, lattice_info[1])
@@ -68,7 +68,7 @@ function get_intrinsic_crystal_type(cl::Type)
 end
 
 function get_free_params(CP::CrystalPhase)
-    return [get_free_lattice_params(CP.cl)..., CP.act, CP.σ]
+    return vcat(get_free_lattice_params(CP.cl), [CP.act, CP.σ], get_free_params(CP.profile))
 end
 
 function get_free_params(CPs::AbstractVector{<:CrystalPhase})
@@ -79,8 +79,11 @@ function get_free_params(CPs::AbstractVector{<:CrystalPhase})
     p
 end
 
-get_eight_params(CP::CrystalPhase) = [CP.cl.a, CP.cl.b, CP.cl.c, CP.cl.α, CP.cl.β, CP.cl.γ, CP.act, CP.σ]
-get_eight_params(CP::CrystalPhase, θ::AbstractVector) = get_eight_params(CP.cl, θ)
+function get_eight_params(CP::CrystalPhase)
+    vcat([CP.cl.a, CP.cl.b, CP.cl.c, CP.cl.α, CP.cl.β, CP.cl.γ, CP.act, CP.σ], get_free_params(CP.profile))
+end
+
+get_eight_params(CP::CrystalPhase, θ::AbstractVector) = get_eight_parmams(CrystalPhase(CP, θ))
 get_eight_params(crystal::Cubic, θ::AbstractVector) = [θ[1], θ[1], θ[1], pi/2, pi/2, pi/2, θ[2], θ[3]]
 get_eight_params(crystal::Tetragonal, θ::AbstractVector) = [θ[1], θ[1], θ[2], pi/2, pi/2, pi/2, θ[3], θ[4]]
 get_eight_params(crystal::Orthorhombic, θ::AbstractVector) = [θ[1], θ[2], θ[3], pi/2, pi/2, pi/2, θ[4], θ[5]]

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -51,7 +51,6 @@ function optimize!(phases::AbstractVector{<:CrystalPhase},
 	               x::AbstractVector, y::AbstractVector,
                    opt_stn::OptimizationSettings)
 	θ = get_free_params(phases)
-
 	optimize!(θ, phases, x, y, opt_stn)
 end
 
@@ -82,7 +81,7 @@ function initialize_activation!(θ::AbstractVector, phases::AbstractVector,
 	for phase in phases
         param_num = get_param_nums(phase)
 		p = evaluate(phase, θ, x)
-		new_θ[start + param_num - 2] = dot(p, y) / sum(abs2, p)
+		new_θ[start + param_num - 2 - get_param_nums(phase.profile)] = dot(p, y) / sum(abs2, p)
         start += param_num
 	end
 	return new_θ

--- a/src/peakprofile.jl
+++ b/src/peakprofile.jl
@@ -31,7 +31,7 @@ end
 const PseudoVoigt = PseudoVoigtProfile
 (P::PseudoVoigt)(x::Real) = P.α * Lorentz()(x) + (1-P.α) * Gauss()(x)
 get_param_nums(P::PseudoVoigtProfile) = length(P.α)
-get_free_params(P::PseudoVoigtProfile) = P.α
+get_free_params(P::PseudoVoigtProfile) = [P.α]
 
 ########################## mixture of peak profiles ############################
 # θ parameters of mixture (peak parameters x number of peaks)

--- a/test/background.jl
+++ b/test/background.jl
@@ -1,0 +1,29 @@
+using CrystalShift
+using CrystalShift: CrystalPhase, optimize!, evaluate, get_free_params
+using CrystalShift: newton!, get_free_lattice_params
+
+using LinearAlgebra
+using Random: rand
+using Test
+
+verbose = false
+residual_tol = 0.1 # tolerance for residual norm after optimization
+maxiter = 128 # appears to be required for phase combinations in particular
+
+# Global
+std_noise = 1e-3
+mean_θ = [1., 1, .2]
+std_θ = [.02, 1., 1.]
+# newton_lambda = 1e-2 TODO: make this passable to the newton optimization
+
+test_path = "data/Ta-Sn-O/sticks.csv" # when ]test is executed pwd() = /test
+f = open(test_path, "r")
+
+if Sys.iswindows()
+    s = split(read(f, String), "#\r\n")
+else
+    s = split(read(f, String), "#\n")
+end
+
+cs = CrystalPhase.(String.(s[1:end-1]))
+x = collect(8:.1:60)

--- a/test/crystalphase.jl
+++ b/test/crystalphase.jl
@@ -4,7 +4,7 @@ module Testcrystalshift
 using Test
 using CrystalShift
 using CrystalShift: evaluate!, get_param_nums, get_eight_params, get_free_lattice_params
-using CrystalShift: collect_crystals
+using CrystalShift: collect_crystals, Lorentz, PseudoVoigt
 using NPZ
 
 path = "../data/"
@@ -19,7 +19,7 @@ else
     s = split(read(f, String), "#\n")
 end
 
-cs = CrystalPhase.(String.(s[1:end-1]))
+cs = CrystalPhase.(String.(s[1:end-1]), (0.1,), (Lorentz(),))
 x = collect(8:.1:60)
 y = zero(x)
 
@@ -72,5 +72,55 @@ end
         @test multi_sol[i,:] ≈ e
     end
 end
+
+# cs = CrystalPhase.(String.(s[1:end-1]), (0.1,), (PseudoVoigt(0.5),))
+# x = collect(8:.1:60)
+# y = zero(x)
+
+# @testset "Helper functions Voigt" begin
+#     @test Bool(cs[1]) == true 
+#     @test Bool(cs) == true
+#     @test get_param_nums(cs[1]) == 7
+# end
+
+# @testset "Getters Voigt" begin
+#     @test get_eight_params(cs[1]) ≈ [17.11299, 4.872, 5.548, deg2rad(90.0), deg2rad(90.59), deg2rad(90.0), 1.0, 0.1, 0.5]
+#     @test get_eight_params(cs[1], [1., 2., 3., 4., 5., 6.]) == [1., 2., 3., pi/2, 4., pi/2, 5., 6., 0.5]
+#     @test get_eight_params(cs[2], [1., 2., 3.]) == [1., 1., 1., pi/2, pi/2, pi/2, 2., 3., 0.5]
+#     @test get_eight_params(cs[6], [1., 2., 3., 4., 5.]) == [1., 2., 3., pi/2, pi/2, pi/2, 4., 5., 0.5]
+#     @test get_eight_params(cs[10], [1., 2., 3., 4.]) == [1., 1., 2., pi/2, pi/2, pi/2, 3., 4., 0.5]
+
+#     @test get_free_lattice_params(cs[1]) ≈ [17.11299, 4.872, 5.548, deg2rad(90.59)]
+#     @test get_free_lattice_params(cs[1], [1., 2., 3., 4., 5., 6.]) == [1., 2., 3., 5.]
+#     @test get_free_lattice_params(cs[2], [1., 2., 3., 4., 5., 6.]) == [1.]
+#     @test get_free_lattice_params(cs[6], [1., 2., 3., 4., 5., 6.]) == [1., 2., 3.]
+#     @test get_free_lattice_params(cs[10], [1., 2., 3., 4., 5., 6.]) == [1., 3.]
+
+#     @test collect_crystals(cs[1:3]) == [cs[1].cl, cs[2].cl, cs[3].cl]
+# end
+
+# # Test construction with 5 phases from different crystal family
+# @testset "Single phase evaluation Voigt" begin
+#     pn = [1,2,5,6,10]
+#     for i in eachindex(pn)
+#         e = zero(x)
+#         sol[i,:] ./= maximum(sol[i,:])
+#         evaluate!(e, cs[pn[i]], x)
+#         e ./= maximum(e)
+#         @test sol[i,:] ≈ e
+#     end
+# end
+
+# @testset "Multiphase evaluation Voigt" begin
+#     pn = [[1,2], [1,5], [2,5], [5,6], [6,10]]
+#     for i in eachindex(pn)
+#         e = zero(x)
+#         multi_sol[i,:] ./= maximum(multi_sol[i,:])
+#         evaluate!(e, cs[pn[i]], x)
+#         e ./= maximum(e)
+#         @test multi_sol[i,:] ≈ e
+#     end
+# end
+
 
 end # modules

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -41,7 +41,7 @@ function test_optimize(cp::CrystalPhase, x::AbstractVector,
         println("sol: $(sol)")
         println(c[1].origin_cl)
     end
-    
+
     norm(c.(x).-y)
 end
 
@@ -72,7 +72,7 @@ function synthesize_multiphase_data(cps::AbstractVector{<:CrystalPhase},
 
         scaling = (interval_size.*rand(size(params, 1)).-interval_size/2).+1
         @. params = params*scaling
-        params = vcat(params, 0.5.+3rand(1), 0.1.+0.1(rand(1)), 0.1.+0.1(rand(1)))
+        params = vcat(params, 0.5.+3rand(1), 0.1.+0.1(rand(1)), (rand(1)))
         full_params = vcat(full_params, params)
     end
     r = evaluate(cps, full_params, x)


### PR DESCRIPTION
This PR incorporates the `PsuedoVoigt` peak profile defined in `src/peakprofile.jl` into the optimization. This include the following changes:

- Proper management of the to be optimized parameters vector
- Proper generation of test data generation (also fix one previous bug related to this)
