### PR TITLE
Update to have a fixed psuedovoigt option

### DIFF
--- a/src/crystalphase.jl
+++ b/src/crystalphase.jl
@@ -48,10 +48,15 @@ function CrystalPhase(CP::CrystalPhase, θ::AbstractVector)
     cl = get_intrinsic_crystal_type(typeof(CP.cl))
     profile_type = get_intrinsic_profile_type(typeof(CP.profile))
     t = eltype(θ)
-    c = CrystalPhase(cl{t}(θ[1:fp]...), CP.origin_cl, CP.peaks, CP.id, CP.name,
-    # θ[fp+1], θ[fp+2], CP.profile, CP.norm_constant)
-                   θ[fp+1], θ[fp+2], profile_type{t}(θ[fp+3:fp+2+profile_param_num]...),
-                   CP.norm_constant)
+    if profile_param_num >0
+        c = CrystalPhase(cl{t}(θ[1:fp]...), CP.origin_cl, CP.peaks, CP.id, CP.name,
+        # θ[fp+1], θ[fp+2], CP.profile, CP.norm_constant)
+                    θ[fp+1], θ[fp+2], profile_type{t}(θ[fp+3:fp+2+profile_param_num]...),
+                    CP.norm_constant)
+    else
+        c = CrystalPhase(cl{t}(θ[1:fp]...), CP.origin_cl, CP.peaks, CP.id, CP.name,
+        θ[fp+1], θ[fp+2], CP.profile, CP.norm_constant)
+    end
     return c
 end
 

--- a/src/peakprofile.jl
+++ b/src/peakprofile.jl
@@ -55,6 +55,16 @@ function PseudoVoigt(a::AbstractVector)
    PseudoVoigt{eltype(a)}(a[1])
 end
 
+struct FixedPseudoVoigtProfile{T} <: PeakProfile{T}
+   α::T
+end
+
+const FixedPseudoVoigt = FixedPseudoVoigtProfile
+FixedPseudoVoigt(a::Float64) = FixedPseudoVoigt{Float64}(a)
+(P::FixedPseudoVoigt)(x::Real) = (-0.5+P.α) * Lorentz()(x) + (1.5-P.α) * Gauss()(x)
+get_param_nums(P::FixedPseudoVoigt) = 0
+get_free_params(P::FixedPseudoVoigt) = []
+
 ########################## mixture of peak profiles ############################
 # θ parameters of mixture (peak parameters x number of peaks)
 # function mixture!(y::AbstractVector, P::PeakProfile,

--- a/test/BFGS.jl
+++ b/test/BFGS.jl
@@ -1,7 +1,7 @@
 using CrystalShift
 using CrystalShift: CrystalPhase, optimize!, evaluate, get_free_params
 using CrystalShift: newton!, get_free_lattice_params
-using CrystalShift: BackgroundModel, evaluate!, PhaseModel, Lorentz
+using CrystalShift: BackgroundModel, evaluate!, PhaseModel, Lorentz, FixedPseudoVoigt
 using CovarianceFunctions
 using CovarianceFunctions: EQ
 
@@ -30,7 +30,7 @@ else
     s = split(read(f, String), "#\n")
 end
 
-cs = @. CrystalPhase(String(s[1:end-1]), (0.3, ), (Lorentz()))
+cs = @. CrystalPhase(String(s[1:end-1]), (0.3, ), (FixedPseudoVoigt(0.5)))
 x = collect(8:.1:60)
 
 
@@ -39,7 +39,7 @@ function synthesize_data(cp::CrystalPhase, x::AbstractVector)
     interval_size = 0.025
     scaling = (interval_size.*rand(size(params, 1),) .- interval_size/2) .+ 1
     @. params = params*scaling
-    params = [params..., 1., 0.2, 0.5]
+    params = [params..., 1., 0.2]
     r = evaluate(cp, params, x)
     normalization = maximum(r)
     params[end-1] /= normalization


### PR DESCRIPTION
Implemented a `FixPseudoVoigt` object to allow fixed `a` for PseudoVoigt.